### PR TITLE
Improve test coverage and navigation checks

### DIFF
--- a/test/app_router_guard_test.dart
+++ b/test/app_router_guard_test.dart
@@ -11,6 +11,21 @@ class TrackingGuard implements RouteGuard {
   }
 }
 
+class RedirectGuard implements RouteGuard {
+  @override
+  Future<void> check(CurrentRoute currentRoute) async {
+    Navigator.of(currentRoute.context).pushReplacementNamed('/login');
+  }
+}
+
+class RecordingObserver extends NavigatorObserver {
+  final List<String?> pushes = [];
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    pushes.add(route.settings.name);
+  }
+}
+
 void main() {
   testWidgets('AppRouter invokes guards before building page', (tester) async {
     final guard = TrackingGuard();
@@ -34,5 +49,43 @@ void main() {
     ));
     await tester.pumpAndSettle();
     expect(guard.called, isTrue);
+  });
+
+  testWidgets('redirect guard replaces route without double navigation',
+      (tester) async {
+    bool built = false;
+    AppRouter.init(
+      GlobalRouteDefiner(
+        initialRoute: '/',
+        title: 'Test App',
+        onUnknownRoute: (settings, state) =>
+            MaterialPageRoute(builder: (_) => const Placeholder(), settings: settings),
+      ),
+      [
+        RouteDefiner(path: '/login', builder: (_, __) => const Text('Login')),
+        RouteDefiner(
+          path: '/protected',
+          builder: (_, __) {
+            built = true;
+            return const Text('Protected');
+          },
+          guards: [RedirectGuard()],
+        ),
+      ],
+    );
+
+    final observer = RecordingObserver();
+    await tester.pumpWidget(MaterialApp(
+      onGenerateRoute: AppRouter.onGenerateRoute,
+      onUnknownRoute: AppRouter.onUnknownRoute,
+      navigatorObservers: [observer],
+      initialRoute: '/protected',
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Login'), findsOneWidget);
+    expect(find.text('Protected'), findsNothing);
+    expect(built, isFalse);
+    expect(observer.pushes, ['/protected', '/login']);
   });
 }

--- a/test/app_router_test.dart
+++ b/test/app_router_test.dart
@@ -50,6 +50,10 @@ void main() {
       builder: (_, __) => const Scaffold(body: Text('Login')),
     ),
     RouteDefiner(path: '/main', builder: (_, __) => const Placeholder(), isAuthorized: (currentRoute) async => false),
+    RouteDefiner(
+        path: '/secure',
+        builder: (_, __) => const Scaffold(body: Text('Secure')),
+        isAuthorized: (currentRoute) async => true),
     RouteDefiner(path: '/article/:id', builder: (_, __) => const Placeholder()),
     RouteDefiner(path: '/user/:id', builder: (_, __) => const Placeholder()),
     RouteDefiner(
@@ -143,6 +147,16 @@ void main() {
     testWidgets('Handles unauthorized route access', (tester) async {
       await pumpRoute(tester, '/main');
       expect(find.text('Unauthorized'), findsOneWidget);
+    });
+
+    testWidgets('Allows authorized route access', (tester) async {
+      await pumpRoute(tester, '/secure');
+      expect(find.text('Secure'), findsOneWidget);
+    });
+
+    testWidgets('Falls back to unknown route on near match', (tester) async {
+      await pumpRoute(tester, '/settings');
+      expect(find.text('404'), findsOneWidget);
     });
   });
 
@@ -268,6 +282,11 @@ void main() {
     test('extractPathParams extracts params correctly', () {
       final params = AppRouter.extractPathParams('/user/:id', '/user/123');
       expect(params, {'id': '123'});
+    });
+
+    test('onUnknownRoute returns fallback page', () {
+      final route = AppRouter.onUnknownRoute(const RouteSettings(name: '/missing'));
+      expect(route, isA<MaterialPageRoute>());
     });
 
     test('buildRouteState parses RouteSettings correctly', () {

--- a/test/route_options_test.dart
+++ b/test/route_options_test.dart
@@ -7,4 +7,21 @@ void main() {
     final merged = opts.merge(null);
     expect(identical(opts, merged), isTrue);
   });
+
+  test('merge combines non-null fields correctly', () {
+    const base = RouteOptions(
+      maintainState: true,
+      fullscreenDialog: false,
+      allowSnapshotting: true,
+      barrierDismissible: false,
+      requestFocus: true,
+    );
+    const override = RouteOptions(fullscreenDialog: true, barrierDismissible: true);
+    final merged = base.merge(override);
+    expect(merged.fullscreenDialog, isTrue);
+    expect(merged.maintainState, isTrue);
+    expect(merged.allowSnapshotting, isTrue);
+    expect(merged.barrierDismissible, isTrue);
+    expect(merged.requestFocus, isTrue);
+  });
 }

--- a/test/title_observer_test.dart
+++ b/test/title_observer_test.dart
@@ -18,6 +18,11 @@ void main() {
           title: () async => 'Route Title',
         ),
         RouteDefiner(path: '/noTitle', builder: (_, __) => const Placeholder()),
+        RouteDefiner(
+          path: '/error',
+          builder: (_, __) => const Placeholder(),
+          title: () async => throw Exception('oops'),
+        ),
       ],
     );
   });
@@ -50,5 +55,81 @@ void main() {
     );
     await tester.pump();
     expect(captured, isNull);
+  });
+
+  testWidgets('didReplace uses new route when provided', (tester) async {
+    String? captured;
+    final observer = TitleObserver(appTitle: (app, route) {
+      captured = route;
+      return '';
+    });
+    observer.didReplace(
+      newRoute: MaterialPageRoute(
+          settings: const RouteSettings(name: '/withTitle'),
+          builder: (_) => const Placeholder()),
+      oldRoute: null,
+    );
+    await tester.pump();
+    expect(captured, 'Route Title');
+  });
+
+  testWidgets('didReplace ignores when newRoute is null', (tester) async {
+    final observer = TitleObserver(appTitle: (_, __) => '');
+    observer.didReplace(newRoute: null, oldRoute: null);
+    await tester.pump();
+  });
+
+  testWidgets('didPop uses previous route when available', (tester) async {
+    String? captured;
+    final observer = TitleObserver(appTitle: (app, route) {
+      captured = route;
+      return '';
+    });
+    observer.didPop(
+      MaterialPageRoute(
+          settings: const RouteSettings(name: '/noTitle'),
+          builder: (_) => const Placeholder()),
+      MaterialPageRoute(
+          settings: const RouteSettings(name: '/withTitle'),
+          builder: (_) => const Placeholder()),
+    );
+    await tester.pump();
+    expect(captured, 'Route Title');
+  });
+
+  testWidgets('didPop ignores when previousRoute is null', (tester) async {
+    final observer = TitleObserver(appTitle: (_, __) => '');
+    observer.didPop(
+      MaterialPageRoute(
+          settings: const RouteSettings(name: '/noTitle'),
+          builder: (_) => const Placeholder()),
+      null,
+    );
+    await tester.pump();
+  });
+
+  testWidgets('falls back to app title when title builder throws', (tester) async {
+    bool called = false;
+    final observer = TitleObserver(appTitle: (app, route) {
+      called = true;
+      return '';
+    });
+    observer.didPush(
+      MaterialPageRoute(
+          settings: const RouteSettings(name: '/error'),
+          builder: (_) => const Placeholder()),
+      null,
+    );
+    await tester.pump();
+    expect(called, isFalse);
+  });
+
+  test('defaultTitleGenerator formats titles correctly', () {
+    expect(TitleObserver.defaultTitleGenerator('App', 'Home'), 'App | Home');
+    expect(TitleObserver.defaultTitleGenerator('App', null), 'App');
+  });
+
+  test('updateBrowserTitle stub executes without error', () {
+    updateBrowserTitle('Test');
   });
 }


### PR DESCRIPTION
## Summary
- Add redirect guard test to ensure route replacement happens only once
- Expand TitleObserver tests for replace/pop/error cases and stub coverage
- Add RouteOptions merge test and authorized route validation

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0451c84ac83259775387b0cce75c5