### PR TITLE
chore: loosen web dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,6 @@
 - Stabilized public APIs and bumped package version to 2.0.0.
 - Added tests for route guards, title updates, and loader widget to reach full coverage.
 - Verified package readiness for publishing with a perfect pub score.
+
+## [2.0.1] - 2025-08-30
+- Downgraded `web` dependency and allowed any version for maximum adaptability.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: route_definer
 description: An advanced router for Flutter with support for parsing routes, parameters, and guards.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/arlamend7/flutter_route_definer
 repository: https://github.com/arlamend7/flutter_route_definer
 issue_tracker: https://github.com/arlamend7/flutter_route_definer/issues
@@ -15,7 +15,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  web: ^1.1.1
+  web: any
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- bump version to 2.0.1
- relax `web` dependency to allow any version for broader adaptability

## Testing
- `dart format .` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b37aa6d58c832594375e7a5b4ff99b