### PR TITLE
chore: export all classes and bump version to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,6 @@
 
 ## [2.0.1] - 2025-08-30
 - Downgraded `web` dependency and allowed any version for maximum adaptability.
+
+## [2.0.2] - 2025-08-31
+- Exported all core classes in `route_definer.dart` for easier package consumption.

--- a/lib/route_definer.dart
+++ b/lib/route_definer.dart
@@ -10,5 +10,8 @@ export 'src/route_guard.dart';
 export 'src/route_state.dart';
 export 'src/global_route_definer.dart';
 export 'src/route_options.dart';
+export 'src/current_route.dart';
+export 'src/deafault_guard_handler_page.dart';
+export 'src/title_observer.dart';
 export 'navigations/title_updater_stub.dart'
     if (dart.library.html) 'navigations/title_updater.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: route_definer
 description: An advanced router for Flutter with support for parsing routes, parameters, and guards.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/arlamend7/flutter_route_definer
 repository: https://github.com/arlamend7/flutter_route_definer
 issue_tracker: https://github.com/arlamend7/flutter_route_definer/issues


### PR DESCRIPTION
## Summary
- export all remaining core classes from `route_definer.dart`
- bump package version to 2.0.2 and update changelog

## Testing
- `dart format lib/route_definer.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b383b9f1948325967b27298a494fc1