### PR TITLE
chore: refine tests and type-safe route state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,7 @@
 
 ## [2.0.2] - 2025-08-31
 - Exported all core classes in `route_definer.dart` for easier package consumption.
+
+## [2.0.3] - 2025-09-08
+- Replaced `dynamic` with `Object?` for `RouteState.arguments` to improve type safety.
+- Refined and documented test suite for clearer coverage.

--- a/lib/src/route_state.dart
+++ b/lib/src/route_state.dart
@@ -15,7 +15,7 @@ class RouteState {
   final String fragment;
 
   /// Optional arguments passed along with the route.
-  final dynamic arguments;
+  final Object? arguments;
 
   /// Creates a [RouteState] object with all the relevant route information.
   ///

--- a/test/app_router_guard_test.dart
+++ b/test/app_router_guard_test.dart
@@ -3,14 +3,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:route_definer/route_definer.dart';
 import 'package:route_definer/src/current_route.dart';
 
+/// Guard used to track whether [check] was invoked.
 class TrackingGuard implements RouteGuard {
+  /// Indicates if [check] was called.
   bool called = false;
+
   @override
   Future<void> check(CurrentRoute currentRoute) async {
     called = true;
   }
 }
 
+/// Guard that always redirects to `/login`.
 class RedirectGuard implements RouteGuard {
   @override
   Future<void> check(CurrentRoute currentRoute) async {
@@ -18,30 +22,35 @@ class RedirectGuard implements RouteGuard {
   }
 }
 
+/// NavigatorObserver that records pushed route names.
 class RecordingObserver extends NavigatorObserver {
-  final List<String?> pushes = [];
+  /// Sequence of route names pushed.
+  final List<String?> pushes = <String?>[];
+
   @override
-  void didPush(Route route, Route? previousRoute) {
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     pushes.add(route.settings.name);
   }
 }
 
+/// Tests for guard-related behavior in [AppRouter].
 void main() {
-  testWidgets('AppRouter invokes guards before building page', (tester) async {
-    final guard = TrackingGuard();
+  testWidgets('AppRouter invokes guards before building page',
+      (WidgetTester tester) async {
+    final TrackingGuard guard = TrackingGuard();
     AppRouter.init(
       GlobalRouteDefiner(
         initialRoute: '/',
         title: 'Test App',
-        onUnknownRoute: (settings, state) => MaterialPageRoute(
-            builder: (_) => const Placeholder(), settings: settings),
+        onUnknownRoute: (RouteSettings settings, RouteState state) =>
+            MaterialPageRoute(builder: (_) => const Placeholder(), settings: settings),
       ),
-      [
+      <RouteDefiner>[
         RouteDefiner(path: '/', builder: (_, __) => const Placeholder()),
         RouteDefiner(
             path: '/guarded',
             builder: (_, __) => const Placeholder(),
-            guards: [guard]),
+            guards: <RouteGuard>[guard]),
       ],
     );
 
@@ -55,16 +64,16 @@ void main() {
   });
 
   testWidgets('redirect guard replaces route without double navigation',
-      (tester) async {
+      (WidgetTester tester) async {
     bool built = false;
     AppRouter.init(
       GlobalRouteDefiner(
         initialRoute: '/',
         title: 'Test App',
-        onUnknownRoute: (settings, state) => MaterialPageRoute(
-            builder: (_) => const Placeholder(), settings: settings),
+        onUnknownRoute: (RouteSettings settings, RouteState state) =>
+            MaterialPageRoute(builder: (_) => const Placeholder(), settings: settings),
       ),
-      [
+      <RouteDefiner>[
         RouteDefiner(path: '/login', builder: (_, __) => const Text('Login')),
         RouteDefiner(
           path: '/protected',
@@ -72,16 +81,16 @@ void main() {
             built = true;
             return const Text('Protected');
           },
-          guards: [RedirectGuard()],
+          guards: <RouteGuard>[RedirectGuard()],
         ),
       ],
     );
 
-    final observer = RecordingObserver();
+    final RecordingObserver observer = RecordingObserver();
     await tester.pumpWidget(MaterialApp(
       onGenerateRoute: AppRouter.onGenerateRoute,
       onUnknownRoute: AppRouter.onUnknownRoute,
-      navigatorObservers: [observer],
+      navigatorObservers: <NavigatorObserver>[observer],
       initialRoute: '/protected',
     ));
     await tester.pumpAndSettle();
@@ -89,6 +98,6 @@ void main() {
     expect(find.text('Login'), findsOneWidget);
     expect(find.text('Protected'), findsNothing);
     expect(built, isFalse);
-    expect(observer.pushes, ['/protected', '/login']);
+    expect(observer.pushes, <String?>['/protected', '/login']);
   });
 }

--- a/test/app_router_test.dart
+++ b/test/app_router_test.dart
@@ -1,12 +1,16 @@
-// test/route_definer_test.dart
+/// Tests covering [AppRouter] features and utilities.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:route_definer/route_definer.dart';
 import 'package:route_definer/src/current_route.dart';
 
+/// A guard that can optionally block navigation.
 class DummyGuard implements RouteGuard {
+  /// Whether navigation is allowed.
   final bool allow;
+
+  /// Creates a [DummyGuard] with the desired [allow] behavior.
   DummyGuard(this.allow);
 
   @override
@@ -17,11 +21,16 @@ class DummyGuard implements RouteGuard {
   }
 }
 
+/// Simple mutable store mimicking user preferences for tests.
 class DummyUserPrefs {
+  /// Whether the user is authenticated.
   static bool isAuthenticated = false;
-  static dynamic passwordChange;
+
+  /// Tracks password change progress if any.
+  static Object? passwordChange;
 }
 
+/// Guard that redirects authenticated users to `/main`.
 class AuthenticatedRedirectGuard extends RouteGuard {
   @override
   Future<void> check(CurrentRoute route) async {
@@ -31,19 +40,22 @@ class AuthenticatedRedirectGuard extends RouteGuard {
   }
 }
 
+/// Guard ensuring password reset has an email or existing progress.
 class PasswordChangeProgressGuard extends RouteGuard {
   @override
   Future<void> check(CurrentRoute route) async {
-    final args = route.state.arguments;
-    final emailPresent = args != null && args['email'] != null;
+    final Object? args = route.state.arguments;
+    final bool emailPresent =
+        args is Map<String, Object?> && args['email'] != null;
     if (!(emailPresent || DummyUserPrefs.passwordChange != null)) {
       Navigator.of(route.context).pushReplacementNamed('/login');
     }
   }
 }
 
+/// Entry point for [AppRouter] tests.
 void main() {
-  final mockRoutes = [
+  final List<RouteDefiner> mockRoutes = [
     RouteDefiner(path: '/', builder: (_, __) => const Placeholder()),
     RouteDefiner(
       path: '/login',
@@ -109,6 +121,7 @@ void main() {
   });
 
   group('AppRouter', () {
+    /// Renders [route] using the router and settles animations.
     Future<void> pumpRoute(WidgetTester tester, String route) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -164,93 +177,7 @@ void main() {
     });
   });
 
-  group('RouteGuard tests', () {
-    // test('DummyGuard allows when true', () {
-    //   final guard = DummyGuard(true);
-    //   final state = RouteState(
-    //     path: '/home',
-    //     queryParams: {},
-    //     fragment: '',
-    //     arguments: null,
-    //   );
-    //   expect(guard.check(state), isNull);
-    // });
-
-    // test('DummyGuard blocks and redirects when false', () {
-    //   final guard = DummyGuard(false);
-    //   final state = RouteState(
-    //     path: '/home',
-    //     queryParams: {},
-    //     fragment: '',
-    //     arguments: null,
-    //   );
-    //   expect(guard.redirect(state), '/login');
-    // });
-
-    // group('AuthenticatedRedirectGuard', () {
-    //   test('Redirects to /main when authenticated', () {
-    //     DummyUserPrefs.isAuthenticated = true;
-    //     final guard = AuthenticatedRedirectGuard();
-    //     final state = RouteState(
-    //       path: AppRouter.initialRoute,
-    //       queryParams: {},
-    //       fragment: '',
-    //       arguments: null,
-    //     );
-    //     expect(guard.redirect(state), '/main');
-    //   });
-
-    //   test('Allows access when not authenticated', () {
-    //     DummyUserPrefs.isAuthenticated = false;
-    //     final guard = AuthenticatedRedirectGuard();
-    //     final state = RouteState(
-    //       path: '/',
-    //       queryParams: {},
-    //       fragment: '',
-    //       arguments: null,
-    //     );
-    //     expect(guard.redirect(state), isNull);
-    //   });
-  });
-
-  group('PasswordChangeProgressGuard', () {
-    //   test('Allows if email argument is present', () {
-    //     final guard = PasswordChangeProgressGuard();
-    //     final state = RouteState(
-    //       path: '/password-change',
-    //       queryParams: {},
-    //       fragment: '',
-    //       arguments: {'email': 'test@example.com'},
-    //     );
-    //     expect(guard.redirect(state), isNull);
-    //   });
-
-    //   test('Allows if local passwordChange progress exists', () {
-    //     DummyUserPrefs.passwordChange = {'step': 1};
-    //     final guard = PasswordChangeProgressGuard();
-    //     final state = RouteState(
-    //       path: '/password-change',
-    //       queryParams: {},
-    //       fragment: '',
-    //       arguments: {},
-    //     );
-    //     expect(guard.redirect(state), isNull);
-    //     DummyUserPrefs.passwordChange = null;
-    //   });
-
-    //   test('Redirects to / when no progress or email', () {
-    //     DummyUserPrefs.passwordChange = null;
-    //     final guard = PasswordChangeProgressGuard();
-    //     final state = RouteState(
-    //       path: '/password-change',
-    //       queryParams: {},
-    //       fragment: '',
-    //       arguments: {},
-    //     );
-    //     expect(guard.redirect(state), AppRouter.initialRoute);
-    //   });
-    // });
-  });
+  // Guard-specific behavior is covered in app_router_guard_test.dart
 
   group('AppRouter static helper methods', () {
     group('isNearMatch', () {
@@ -303,7 +230,7 @@ void main() {
       expect(state.path, '/page');
       expect(state.queryParams, containsPair('query', 'test'));
       expect(state.fragment, 'frag');
-      expect(state.arguments, containsPair('some', 'data'));
+      expect(state.arguments as Map<String, Object?>, containsPair('some', 'data'));
     });
 
     group('matchRoute', () {
@@ -365,7 +292,7 @@ void main() {
       expect(result.state.uriParams, isNull);
       expect(result.state.queryParams, isEmpty);
       expect(result.state.fragment, 'section1');
-      expect(result.state.arguments, containsPair('foo', 'bar'));
+      expect(result.state.arguments as Map<String, Object?>, containsPair('foo', 'bar'));
       expect(result.match, isNull);
       expect(result.isNear, isFalse);
     });
@@ -453,7 +380,7 @@ void main() {
       expect(state.uriParams, isNull);
       expect(state.queryParams, isEmpty);
       expect(state.fragment, 'section1');
-      expect(state.arguments, containsPair('foo', 'bar'));
+      expect(state.arguments as Map<String, Object?>, containsPair('foo', 'bar'));
     });
 
     test('buildRouteState parses multiple query parameters correctly', () {

--- a/test/route_loader_widget_test.dart
+++ b/test/route_loader_widget_test.dart
@@ -4,26 +4,28 @@ import 'package:route_definer/route_definer.dart';
 import 'package:route_definer/src/current_route.dart';
 import 'package:route_definer/src/deafault_guard_handler_page.dart';
 
+/// Tests for [RouteLoaderWidget] guard and authentication handling.
 void main() {
   testWidgets('shows auth widget when authentication provides one',
-      (tester) async {
-    final route =
+      (WidgetTester tester) async {
+    final RouteDefiner route =
         RouteDefiner(path: '/dummy', builder: (_, __) => const Text('Final'));
-    final state = RouteState(
+    final RouteState state = RouteState(
         path: '/dummy',
         uriParams: null,
-        queryParams: const {},
+        queryParams: const <String, String>{},
         fragment: '',
         arguments: null);
 
     await tester.pumpWidget(MaterialApp(
-      home: Builder(builder: (ctx) {
-        final current = CurrentRoute(context: ctx, route: route, state: state);
+      home: Builder(builder: (BuildContext ctx) {
+        final CurrentRoute current =
+            CurrentRoute(context: ctx, route: route, state: state);
         return RouteLoaderWidget(
           currentRoute: current,
           loader: const Text('Loading'),
           guardStream: const Stream.empty(),
-          authenticationTask: Future.value(const Text('Auth')),
+          authenticationTask: Future<Widget?>.value(const Text('Auth')),
         );
       }),
     ));
@@ -32,24 +34,26 @@ void main() {
     expect(find.text('Auth'), findsOneWidget);
   });
 
-  testWidgets('builds final page after guards complete', (tester) async {
-    final route =
+  testWidgets('builds final page after guards complete',
+      (WidgetTester tester) async {
+    final RouteDefiner route =
         RouteDefiner(path: '/dummy', builder: (_, __) => const Text('Final'));
-    final state = RouteState(
+    final RouteState state = RouteState(
         path: '/dummy',
         uriParams: null,
-        queryParams: const {},
+        queryParams: const <String, String>{},
         fragment: '',
         arguments: null);
 
     await tester.pumpWidget(MaterialApp(
-      home: Builder(builder: (ctx) {
-        final current = CurrentRoute(context: ctx, route: route, state: state);
+      home: Builder(builder: (BuildContext ctx) {
+        final CurrentRoute current =
+            CurrentRoute(context: ctx, route: route, state: state);
         return RouteLoaderWidget(
           currentRoute: current,
           loader: const Text('Loading'),
           guardStream: Stream<void>.value(null),
-          authenticationTask: Future.value(null),
+          authenticationTask: Future<Widget?>.value(null),
         );
       }),
     ));

--- a/test/route_options_test.dart
+++ b/test/route_options_test.dart
@@ -1,24 +1,25 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:route_definer/route_definer.dart';
 
+/// Tests for merging behavior of [RouteOptions].
 void main() {
   test('merge returns this when other is null', () {
-    const opts = RouteOptions(fullscreenDialog: true);
-    final merged = opts.merge(null);
+    const RouteOptions opts = RouteOptions(fullscreenDialog: true);
+    final RouteOptions merged = opts.merge(null);
     expect(identical(opts, merged), isTrue);
   });
 
   test('merge combines non-null fields correctly', () {
-    const base = RouteOptions(
+    const RouteOptions base = RouteOptions(
       maintainState: true,
       fullscreenDialog: false,
       allowSnapshotting: true,
       barrierDismissible: false,
       requestFocus: true,
     );
-    const override =
+    const RouteOptions override =
         RouteOptions(fullscreenDialog: true, barrierDismissible: true);
-    final merged = base.merge(override);
+    final RouteOptions merged = base.merge(override);
     expect(merged.fullscreenDialog, isTrue);
     expect(merged.maintainState, isTrue);
     expect(merged.allowSnapshotting, isTrue);

--- a/test/title_observer_test.dart
+++ b/test/title_observer_test.dart
@@ -3,16 +3,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:route_definer/route_definer.dart';
 import 'package:route_definer/src/title_observer.dart';
 
+/// Tests for [TitleObserver] behavior.
 void main() {
   setUp(() {
     AppRouter.init(
       GlobalRouteDefiner(
         initialRoute: '/',
         title: 'App',
-        onUnknownRoute: (settings, state) => MaterialPageRoute(
-            builder: (_) => const Placeholder(), settings: settings),
+        onUnknownRoute: (RouteSettings settings, RouteState state) =>
+            MaterialPageRoute(builder: (_) => const Placeholder(), settings: settings),
       ),
-      [
+      <RouteDefiner>[
         RouteDefiner(
           path: '/withTitle',
           builder: (_, __) => const Placeholder(),
@@ -28,15 +29,16 @@ void main() {
     );
   });
 
-  testWidgets('uses route-specific title when available', (tester) async {
+  testWidgets('uses route-specific title when available',
+      (WidgetTester tester) async {
     String? captured;
-    final observer = TitleObserver(appTitle: (app, route) {
+    final TitleObserver observer = TitleObserver(appTitle: (String app, String? route) {
       captured = route;
       return '';
     });
 
     observer.didPush(
-      MaterialPageRoute(
+      MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/withTitle'),
           builder: (_) => const Placeholder()),
       null,
@@ -46,15 +48,15 @@ void main() {
   });
 
   testWidgets('falls back to app title when route has no title',
-      (tester) async {
+      (WidgetTester tester) async {
     String? captured;
-    final observer = TitleObserver(appTitle: (app, route) {
+    final TitleObserver observer = TitleObserver(appTitle: (String app, String? route) {
       captured = route;
       return '';
     });
 
     observer.didPush(
-      MaterialPageRoute(
+      MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/noTitle'),
           builder: (_) => const Placeholder()),
       null,
@@ -63,14 +65,15 @@ void main() {
     expect(captured, isNull);
   });
 
-  testWidgets('didReplace uses new route when provided', (tester) async {
+  testWidgets('didReplace uses new route when provided',
+      (WidgetTester tester) async {
     String? captured;
-    final observer = TitleObserver(appTitle: (app, route) {
+    final TitleObserver observer = TitleObserver(appTitle: (String app, String? route) {
       captured = route;
       return '';
     });
     observer.didReplace(
-      newRoute: MaterialPageRoute(
+      newRoute: MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/withTitle'),
           builder: (_) => const Placeholder()),
       oldRoute: null,
@@ -79,23 +82,25 @@ void main() {
     expect(captured, 'Route Title');
   });
 
-  testWidgets('didReplace ignores when newRoute is null', (tester) async {
-    final observer = TitleObserver(appTitle: (_, __) => '');
+  testWidgets('didReplace ignores when newRoute is null',
+      (WidgetTester tester) async {
+    final TitleObserver observer = TitleObserver(appTitle: (_, __) => '');
     observer.didReplace(newRoute: null, oldRoute: null);
     await tester.pump();
   });
 
-  testWidgets('didPop uses previous route when available', (tester) async {
+  testWidgets('didPop uses previous route when available',
+      (WidgetTester tester) async {
     String? captured;
-    final observer = TitleObserver(appTitle: (app, route) {
+    final TitleObserver observer = TitleObserver(appTitle: (String app, String? route) {
       captured = route;
       return '';
     });
     observer.didPop(
-      MaterialPageRoute(
+      MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/noTitle'),
           builder: (_) => const Placeholder()),
-      MaterialPageRoute(
+      MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/withTitle'),
           builder: (_) => const Placeholder()),
     );
@@ -103,10 +108,11 @@ void main() {
     expect(captured, 'Route Title');
   });
 
-  testWidgets('didPop ignores when previousRoute is null', (tester) async {
-    final observer = TitleObserver(appTitle: (_, __) => '');
+  testWidgets('didPop ignores when previousRoute is null',
+      (WidgetTester tester) async {
+    final TitleObserver observer = TitleObserver(appTitle: (_, __) => '');
     observer.didPop(
-      MaterialPageRoute(
+      MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/noTitle'),
           builder: (_) => const Placeholder()),
       null,
@@ -115,14 +121,14 @@ void main() {
   });
 
   testWidgets('falls back to app title when title builder throws',
-      (tester) async {
+      (WidgetTester tester) async {
     bool called = false;
-    final observer = TitleObserver(appTitle: (app, route) {
+    final TitleObserver observer = TitleObserver(appTitle: (String app, String? route) {
       called = true;
       return '';
     });
     observer.didPush(
-      MaterialPageRoute(
+      MaterialPageRoute<void>(
           settings: const RouteSettings(name: '/error'),
           builder: (_) => const Placeholder()),
       null,


### PR DESCRIPTION
## Summary
- add documentation and explicit types across tests
- replace `dynamic` with `Object?` for `RouteState.arguments`
- document test suite in CHANGELOG

## Testing
- `flutter test` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec2a8a0d88325a10265b8515218ff